### PR TITLE
Feature/void new storage

### DIFF
--- a/additional-types.json
+++ b/additional-types.json
@@ -51,5 +51,13 @@
   "File": {
     "hash": "Hash",
     "nature": "Vec<u8>"
+  },
+  "LocVoidInfo": {
+    "_enum": {
+      "V1": {
+        "reason": "Vec<u8>",
+        "replacer": "Option<LocLink<LocId>>"
+      }
+    }
   }
 }

--- a/docs/storage_backward_compatibility.md
+++ b/docs/storage_backward_compatibility.md
@@ -1,0 +1,67 @@
+# Introduction
+Given that blockchain stored data are serialized/deserialized using the
+[SCALE Codec](https://docs.substrate.io/v3/advanced/scale-codec/), any change to the runtime must be carefully
+examined to determine whether it's backward-compatible or not.
+A change is backward compatible if the new runtime is able to decode data created with the previous version(s) of the runtime.
+
+If not backward-compatible, a migration must be added to the new runtime.
+
+# Storage items
+Adding new storage items is backward compatible, provided that following rules are respected:
+* Struct are not modified.
+* Enums only get new values, added at the end of the list.
+
+# Struct
+Adding and/or removing fields is **not** backward compatible.
+If the struct is stored in a [Substrate storage item](https://docs.substrate.io/v3/runtime/storage/#storage-items), the whole item is impacted, not only
+the single entry that contains the additional or lacks the removed field.
+
+# TypedEnum
+It's possible to make a Struct change in time using `TypedEnum` - a new enum entry has to be created each time
+the struct changes, and vll versions must be kept (and not re-ordered):
+
+Example: in this example, we needed this struct to get 2 new fields:
+So
+```rust
+pub enum LocVoidInfo<LocId> {
+  V1 {
+    reason: Vec<u8>,
+    replacer: Option<LocLink<LocId>>,
+  },
+  V2 {
+    reason: Vec<u8>,
+    first_replacer: LocLink<LocId>,
+    second_replacer: LocLink<LocId>,
+  }
+}
+```
+is backward compatible with:
+```rust
+pub enum LocVoidInfo<LocId> {
+  V1 {
+    reason: Vec<u8>,
+    replacer: Option<LocLink<LocId>>,
+  }
+}
+```
+The LocInfo bytes created when only `V1` existed will be correctly decoded by the new `LocVoidInfo`containing the V2 struct.
+
+## User-defined types
+[TypedEnum](https://polkadot.js.org/docs/api/start/types.extend/#user-defined-enum) are implemented this way:
+```json
+{
+  "LocVoidInfo": {
+    "_enum": {
+      "V1": {
+        "reason": "Vec<u8>",
+        "replacer": "Option<LocLink<LocId>>"
+      }
+    }
+  }
+}
+```
+
+# Storage migration
+When a given change is not backward-compatible, it's possible to [migrate storage](https://docs.substrate.io/v3/runtime/upgrades/#storage-migrations) from one version
+to the other, by providing one method that will explicitly migrate the data.
+

--- a/pallets/logion_loc/src/tests.rs
+++ b/pallets/logion_loc/src/tests.rs
@@ -5,7 +5,7 @@ use sp_runtime::traits::Hash;
 
 use logion_shared::LocQuery;
 
-use crate::{File, LegalOfficerCase, LocLink, LocType, MetadataItem, mock::*};
+use crate::{File, LegalOfficerCase, LocLink, LocType, LocVoidInfo, MetadataItem, mock::*};
 use crate::Error;
 
 const LOC_ID: u32 = 0;
@@ -24,6 +24,23 @@ fn it_creates_loc() {
 			loc_type: LocType::Transaction,
 			links: vec![]
 		}));
+	});
+}
+
+#[test]
+fn it_makes_existing_loc_void() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(LogionLoc::create_loc(Origin::signed(LOC_OWNER1), LOC_ID, LOC_REQUESTER, LocType::Transaction));
+		assert_ok!(LogionLoc::make_void(Origin::signed(LOC_OWNER1), LOC_ID, "reason".as_bytes().to_vec(), None));
+
+		let void_info = LogionLoc::loc_void_info(LOC_ID);
+		assert!(void_info.is_some());
+		match void_info.unwrap() {
+			LocVoidInfo::V1 { reason: _reason, replacer: _replacer } => {
+				assert_eq!(_reason, "reason".as_bytes().to_vec());
+				assert_eq!(_replacer, None)
+			}
+		}
 	});
 }
 

--- a/pallets/logion_loc/src/weights.rs
+++ b/pallets/logion_loc/src/weights.rs
@@ -42,6 +42,7 @@ pub trait WeightInfo {
 	fn add_file() -> Weight;
 	fn add_link() -> Weight;
 	fn close() -> Weight;
+	fn make_void() -> Weight;
 }
 
 /// Weights for pallet_logion_loc using the Substrate node and recommended hardware.
@@ -72,6 +73,11 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
+	fn make_void() -> Weight {
+		(42_251_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+	}
 }
 
 // For backwards compatibility and tests
@@ -97,6 +103,11 @@ impl WeightInfo for () {
       .saturating_add(RocksDbWeight::get().writes(1 as Weight))
   }
   fn close() -> Weight {
+    (42_251_000 as Weight)
+      .saturating_add(RocksDbWeight::get().reads(1 as Weight))
+      .saturating_add(RocksDbWeight::get().writes(1 as Weight))
+  }
+  fn make_void() -> Weight {
     (42_251_000 as Weight)
       .saturating_add(RocksDbWeight::get().reads(1 as Weight))
       .saturating_add(RocksDbWeight::get().writes(1 as Weight))

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -107,7 +107,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 100,
+	spec_version: 101,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
This PR is an implementation of the `make_void()` for the pallet `logionLoc`. It uses an extra storage in order to stay backward-compatible with the existing chain data.