### PR TITLE
Refactor storage migration

### DIFF
--- a/pallets/logion_loc/src/lib.rs
+++ b/pallets/logion_loc/src/lib.rs
@@ -2,7 +2,6 @@
 
 pub use pallet::*;
 
-#[macro_use]
 mod migration;
 
 #[cfg(test)]

--- a/pallets/logion_loc/src/lib.rs
+++ b/pallets/logion_loc/src/lib.rs
@@ -147,6 +147,8 @@ pub mod pallet {
 		ReplacerLocAlreadyVoid,
 		/// Occurs when trying to void a LOC by replacing it with a LOC already replacing another LOC
 		ReplacerLocAlreadyReplacing,
+		/// Occurs when trying to mutate a void LOC
+		CannotMutateVoid,
 	}
 
 	#[pallet::hooks]
@@ -230,6 +232,8 @@ pub mod pallet {
 					Err(Error::<T>::Unauthorized)?
 				} else if loc.closed {
 					Err(Error::<T>::CannotMutate)?
+				} else if loc.void_info.is_some() {
+					Err(Error::<T>::CannotMutateVoid)?
 				} else {
 					<LocMap<T>>::mutate(loc_id, |loc| {
 						let mutable_loc = loc.as_mut().unwrap();
@@ -257,6 +261,8 @@ pub mod pallet {
 					Err(Error::<T>::Unauthorized)?
 				} else if loc.closed {
 					Err(Error::<T>::CannotMutate)?
+				} else if loc.void_info.is_some() {
+					Err(Error::<T>::CannotMutateVoid)?
 				} else {
 					<LocMap<T>>::mutate(loc_id, |loc| {
 						let mutable_loc = loc.as_mut().unwrap();
@@ -284,6 +290,8 @@ pub mod pallet {
 					Err(Error::<T>::Unauthorized)?
 				} else if loc.closed {
 					Err(Error::<T>::CannotMutate)?
+				} else if loc.void_info.is_some() {
+					Err(Error::<T>::CannotMutateVoid)?
 				} else if ! <LocMap<T>>::contains_key(&link.id) {
 					Err(Error::<T>::LinkedLocNotFound)?
 				} else {
@@ -310,6 +318,8 @@ pub mod pallet {
 				let loc = <LocMap<T>>::get(&loc_id).unwrap();
 				if loc.owner != who {
 					Err(Error::<T>::Unauthorized)?
+				} else if loc.void_info.is_some() {
+					Err(Error::<T>::CannotMutateVoid)?
 				} else if loc.closed {
 					Err(Error::<T>::AlreadyClosed)?
 				} else {

--- a/pallets/logion_loc/src/migration.rs
+++ b/pallets/logion_loc/src/migration.rs
@@ -1,0 +1,67 @@
+use frame_support::codec::{Decode, Encode};
+use frame_support::debug;
+use frame_support::traits::Get;
+use frame_support::traits::Vec;
+use frame_support::weights::Weight;
+
+use crate::{Config, File, LegalOfficerCaseOf, LocLink, LocMap, LocType, MetadataItem, pallet, PalletStorageVersion, StorageVersion};
+
+pub fn migrate<T: Config>() -> Weight {
+	do_migrate::<T, _>(StorageVersion::V1, StorageVersion::V2MakeLocVoid, v1::migrate::<T>)
+}
+
+fn do_migrate<T: Config, F>(from: StorageVersion, to:StorageVersion, migration_fn: F) -> Weight
+	where F: FnOnce() -> Weight {
+	debug::RuntimeLogger::init();
+	if <PalletStorageVersion<T>>::get() == from {
+		debug::info!("Starting to migrate from {:?} to {:?}", from, to);
+		let weight = migration_fn();
+		<PalletStorageVersion<T>>::put(to);
+		debug::info!("Migration ended.");
+		weight
+	} else {
+		debug::info!("No Migrating needed.");
+		0
+	}
+}
+
+mod v1 {
+	use super::*;
+
+	#[derive(Encode, Decode, Default, Clone, PartialEq, Eq, Debug)]
+	struct LegalOfficerCaseV1<AccountId, Hash, LocId> {
+		owner: AccountId,
+		requester: AccountId,
+		metadata: Vec<MetadataItem>,
+		files: Vec<File<Hash>>,
+		closed: bool,
+		loc_type: LocType,
+		links: Vec<LocLink<LocId>>,
+	}
+
+	type LegalOfficerCaseOfV1<T> = LegalOfficerCaseV1<<T as frame_system::Config>::AccountId, <T as pallet::Config>::Hash, <T as pallet::Config>::LocId>;
+
+	pub(crate) fn migrate<T: Config>() -> Weight {
+		<LocMap<T>>::translate::<LegalOfficerCaseOfV1<T>, _>(
+			|loc_id: T::LocId, loc: LegalOfficerCaseOfV1<T>| {
+				debug::info!("Migrating LOC: {:?}", loc_id);
+				debug::info!("From: {:?}", loc);
+				let new_loc = LegalOfficerCaseOf::<T> {
+					owner: loc.owner.clone(),
+					requester: loc.requester.clone(),
+					metadata: loc.metadata.clone(),
+					files: loc.files.clone(),
+					closed: loc.closed.clone(),
+					loc_type: loc.loc_type.clone(),
+					links: loc.links.clone(),
+					void_info: None,
+					replacer_of: None,
+				};
+				debug::info!("To: {:?}", new_loc);
+				Some(new_loc)
+			}
+		);
+		let count = <LocMap<T>>::iter().count();
+		T::DbWeight::get().reads_writes(count as Weight + 1, count as Weight + 1)
+	}
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -501,13 +501,13 @@ pub type Executive = frame_executive::Executive<
 mod migration {
 	use super::*;
 	use frame_support::traits::OnRuntimeUpgrade;
-	use pallet_logion_loc::migration as pallet_logion_loc_migration;
+	use pallet_logion_loc;
 
 	pub struct Upgrade;
 
 	impl OnRuntimeUpgrade for Upgrade {
 		fn on_runtime_upgrade() -> Weight {
-			pallet_logion_loc_migration::migrate_to_v2::<Runtime>()
+			pallet_logion_loc::migrate::<Runtime>()
 		}
 	}
 }


### PR DESCRIPTION
* migration moved to external file.
* migration module refactored to better separate boiler plate code from actual migration logic.
* logging added.
* all extrinsics attempting to mutate a void loc fail.