### PR TITLE
Transfer infrastructure fees to Treasury

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3646,6 +3646,7 @@ dependencies = [
  "pallet-timestamp",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
+ "pallet-treasury",
  "pallet-verified-recovery",
  "parity-scale-codec",
  "scale-info",
@@ -4577,6 +4578,23 @@ dependencies = [
  "sp-api",
  "sp-runtime",
  "sp-weights",
+]
+
+[[package]]
+name = "pallet-treasury"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "impl-trait-for-tuples",
+ "pallet-balances",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -318,6 +318,7 @@ fn logion_genesis(
 		},
 		transaction_payment: Default::default(),
 		assets: Default::default(),
+		treasury: Default::default(),
 	}
 }
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -60,6 +60,7 @@ pallet-recovery = { git = "https://github.com/paritytech/substrate", default-fea
 pallet-session = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
 pallet-validator-set = { default-features = false, git = "https://github.com/logion-network/substrate-validator-set.git", package = "substrate-validator-set", branch = "polkadot-v0.9.37" }
 pallet-verified-recovery = { git = "https://github.com/logion-network/logion-pallets", default-features = false,  branch = "polkadot-v0.9.37" }
+pallet-treasury = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.37" }
 
 [build-dependencies]
 substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
@@ -97,6 +98,7 @@ std = [
 	"pallet-transaction-payment/std",
 	"pallet-validator-set/std",
 	"pallet-verified-recovery/std",
+	"pallet-treasury/std",
 	"sp-api/std",
 	"sp-block-builder/std",
 	"sp-consensus-aura/std",


### PR DESCRIPTION
* Infrastructure fees are mostly burnt (80%), but a small part (20%) is transferred to treasury.
* Requests to get some funds (aka spend proposals) can be entered via Polkadot JS App, via the tabs "Governance", then "Treasury".
* With the current setup, proposals can only be approved (or refused) by `Root`, and are settled once a day.

logion-network/logion-internal#816