### PR TITLE
Add (disabled) File Storage and Inclusion fees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3772,7 +3772,7 @@ dependencies = [
 [[package]]
 name = "logion-shared"
 version = "0.1.1"
-source = "git+https://github.com/logion-network/logion-pallets?branch=polkadot-v0.9.39#87cc64b69eb590ad5d8ffcf9a2ca872a8cf5c769"
+source = "git+https://github.com/logion-network/logion-pallets?branch=polkadot-v0.9.39#c5d86fa90ee3129b4006c599daa60205ee23468f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4494,7 +4494,7 @@ dependencies = [
 [[package]]
 name = "pallet-block-reward"
 version = "0.1.0"
-source = "git+https://github.com/logion-network/logion-pallets?branch=polkadot-v0.9.39#87cc64b69eb590ad5d8ffcf9a2ca872a8cf5c769"
+source = "git+https://github.com/logion-network/logion-pallets?branch=polkadot-v0.9.39#c5d86fa90ee3129b4006c599daa60205ee23468f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4533,7 +4533,7 @@ dependencies = [
 [[package]]
 name = "pallet-lo-authority-list"
 version = "0.1.1"
-source = "git+https://github.com/logion-network/logion-pallets?branch=polkadot-v0.9.39#87cc64b69eb590ad5d8ffcf9a2ca872a8cf5c769"
+source = "git+https://github.com/logion-network/logion-pallets?branch=polkadot-v0.9.39#c5d86fa90ee3129b4006c599daa60205ee23468f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4550,7 +4550,7 @@ dependencies = [
 [[package]]
 name = "pallet-logion-loc"
 version = "0.3.0"
-source = "git+https://github.com/logion-network/logion-pallets?branch=polkadot-v0.9.39#87cc64b69eb590ad5d8ffcf9a2ca872a8cf5c769"
+source = "git+https://github.com/logion-network/logion-pallets?branch=polkadot-v0.9.39#c5d86fa90ee3129b4006c599daa60205ee23468f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4565,7 +4565,7 @@ dependencies = [
 [[package]]
 name = "pallet-logion-vault"
 version = "0.1.1"
-source = "git+https://github.com/logion-network/logion-pallets?branch=polkadot-v0.9.39#87cc64b69eb590ad5d8ffcf9a2ca872a8cf5c769"
+source = "git+https://github.com/logion-network/logion-pallets?branch=polkadot-v0.9.39#c5d86fa90ee3129b4006c599daa60205ee23468f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4581,7 +4581,7 @@ dependencies = [
 [[package]]
 name = "pallet-logion-vote"
 version = "0.1.0"
-source = "git+https://github.com/logion-network/logion-pallets?branch=polkadot-v0.9.39#87cc64b69eb590ad5d8ffcf9a2ca872a8cf5c769"
+source = "git+https://github.com/logion-network/logion-pallets?branch=polkadot-v0.9.39#c5d86fa90ee3129b4006c599daa60205ee23468f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4756,7 +4756,7 @@ dependencies = [
 [[package]]
 name = "pallet-verified-recovery"
 version = "0.1.1"
-source = "git+https://github.com/logion-network/logion-pallets?branch=polkadot-v0.9.39#87cc64b69eb590ad5d8ffcf9a2ca872a8cf5c769"
+source = "git+https://github.com/logion-network/logion-pallets?branch=polkadot-v0.9.39#c5d86fa90ee3129b4006c599daa60205ee23468f"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -51,9 +51,8 @@ pub use sp_runtime::{Perbill, Permill};
 
 // Additional imports
 use frame_system::EnsureRoot;
-use logion_shared::{CreateRecoveryCallFactory, MultisigApproveAsMultiCallFactory, MultisigAsMultiCallFactory};
+use logion_shared::{CreateRecoveryCallFactory, MultisigApproveAsMultiCallFactory, MultisigAsMultiCallFactory, DistributionKey};
 use pallet_multisig::Timepoint;
-use pallet_block_reward::DistributionKey;
 
 /// An index to a block.
 pub type BlockNumber = u32;
@@ -379,6 +378,13 @@ parameter_types! {
 	pub const MaxFileNameSize: u32 = 255;
 	pub const MaxTokensRecordDescriptionSize: u32 = 4096;
 	pub const MaxTokensRecordFiles: u32 = 10;
+	pub const FileStorageByteFee: u32 = 0; // File Storage fees disabled for the moment
+	pub const FileStorageEntryFee: u32 = 0; // File Storage fees disabled for the moment
+    pub const FileStorageFeeDistributionKey: DistributionKey = DistributionKey {
+        stakers_percent: Percent::from_percent(0),
+        collators_percent: Percent::from_percent(20),
+        reserve_percent: Percent::from_percent(80),
+    };
 }
 
 impl pallet_logion_loc::Config for Runtime {
@@ -400,6 +406,11 @@ impl pallet_logion_loc::Config for Runtime {
 	type MaxTokensRecordDescriptionSize = MaxTokensRecordDescriptionSize;
 	type MaxTokensRecordFiles = MaxTokensRecordFiles;
 	type WeightInfo = ();
+	type Currency = Balances;
+	type FileStorageByteFee = FileStorageByteFee;
+	type FileStorageEntryFee = FileStorageEntryFee;
+	type FileStorageFeeDistributor = RewardDistributor;
+	type FileStorageFeeDistributionKey = FileStorageFeeDistributionKey;
 }
 
 parameter_types! {
@@ -569,7 +580,7 @@ parameter_types! {
 }
 
 pub struct RewardDistributor();
-impl pallet_block_reward::RewardDistributor<NegativeImbalance>
+impl logion_shared::RewardDistributor<NegativeImbalance, Balance>
     for RewardDistributor
 {
     fn payout_reserve(reward: NegativeImbalance) {


### PR DESCRIPTION
* Inclusion fees are disabled (i.e. 100% is burned)
* File Storage fees are:
  * configured: same distributor as for inflation is used, with a different key.
  * and disabled (`FileStorage[Byte|Entry]Fee` set to 0).