### PR TITLE
Add Ethereum Address type (used for identity LOC creation).

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3827,7 +3827,7 @@ dependencies = [
 [[package]]
 name = "logion-shared"
 version = "0.1.1"
-source = "git+https://github.com/logion-network/logion-pallets?branch=polkadot-v0.9.40#248483c66b582c03bdd68fb8d7620bfc44649b11"
+source = "git+https://github.com/logion-network/logion-pallets?branch=polkadot-v0.9.40#beb0c50f78cab0a33ae8f2131daf0e8ad83908e8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4525,7 +4525,7 @@ dependencies = [
 [[package]]
 name = "pallet-block-reward"
 version = "0.1.0"
-source = "git+https://github.com/logion-network/logion-pallets?branch=polkadot-v0.9.40#248483c66b582c03bdd68fb8d7620bfc44649b11"
+source = "git+https://github.com/logion-network/logion-pallets?branch=polkadot-v0.9.40#beb0c50f78cab0a33ae8f2131daf0e8ad83908e8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4564,7 +4564,7 @@ dependencies = [
 [[package]]
 name = "pallet-lo-authority-list"
 version = "0.1.1"
-source = "git+https://github.com/logion-network/logion-pallets?branch=polkadot-v0.9.40#248483c66b582c03bdd68fb8d7620bfc44649b11"
+source = "git+https://github.com/logion-network/logion-pallets?branch=polkadot-v0.9.40#beb0c50f78cab0a33ae8f2131daf0e8ad83908e8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4581,7 +4581,7 @@ dependencies = [
 [[package]]
 name = "pallet-logion-loc"
 version = "0.4.0"
-source = "git+https://github.com/logion-network/logion-pallets?branch=polkadot-v0.9.40#248483c66b582c03bdd68fb8d7620bfc44649b11"
+source = "git+https://github.com/logion-network/logion-pallets?branch=polkadot-v0.9.40#beb0c50f78cab0a33ae8f2131daf0e8ad83908e8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4598,7 +4598,7 @@ dependencies = [
 [[package]]
 name = "pallet-logion-vault"
 version = "0.1.1"
-source = "git+https://github.com/logion-network/logion-pallets?branch=polkadot-v0.9.40#248483c66b582c03bdd68fb8d7620bfc44649b11"
+source = "git+https://github.com/logion-network/logion-pallets?branch=polkadot-v0.9.40#beb0c50f78cab0a33ae8f2131daf0e8ad83908e8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4614,7 +4614,7 @@ dependencies = [
 [[package]]
 name = "pallet-logion-vote"
 version = "0.1.0"
-source = "git+https://github.com/logion-network/logion-pallets?branch=polkadot-v0.9.40#248483c66b582c03bdd68fb8d7620bfc44649b11"
+source = "git+https://github.com/logion-network/logion-pallets?branch=polkadot-v0.9.40#beb0c50f78cab0a33ae8f2131daf0e8ad83908e8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4789,7 +4789,7 @@ dependencies = [
 [[package]]
 name = "pallet-verified-recovery"
 version = "0.1.1"
-source = "git+https://github.com/logion-network/logion-pallets?branch=polkadot-v0.9.40#248483c66b582c03bdd68fb8d7620bfc44649b11"
+source = "git+https://github.com/logion-network/logion-pallets?branch=polkadot-v0.9.40#beb0c50f78cab0a33ae8f2131daf0e8ad83908e8"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -9,7 +9,7 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_consensus_grandpa::AuthorityId as GrandpaId;
-use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
+use sp_core::{crypto::KeyTypeId, H160, OpaqueMetadata};
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	traits::{
@@ -76,6 +76,9 @@ pub type Hash = sp_core::H256;
 /// LOC ID
 pub type LocId = u128;
 
+/// Ethereum Address
+pub type EthereumAddress = H160;
+
 /// Opaque types. These are used by the CLI to instantiate machinery that don't need to know
 /// the specifics of the runtime. They can then be made to be agnostic over specific formats
 /// of data like extrinsics, allowing for them to continue syncing the network through upgrades
@@ -112,7 +115,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 139,
+	spec_version: 140,
 	impl_version: 2,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 5,
@@ -406,6 +409,7 @@ impl pallet_logion_loc::Config for Runtime {
 	type FileStorageEntryFee = FileStorageEntryFee;
 	type FileStorageFeeDistributor = RewardDistributor;
 	type FileStorageFeeDistributionKey = FileStorageFeeDistributionKey;
+	type EthereumAddress = EthereumAddress;
 }
 
 parameter_types! {


### PR DESCRIPTION
* Added: Ethereum Address type (used for identity LOC creation)
* Companion of https://github.com/logion-network/logion-pallets/pull/16
* `EthereumAddress` type is copied from [parity-common ethereum-types](https://github.com/paritytech/parity-common/blob/master/ethereum-types/src/lib.rs#L19) rather than adding an (almost) useless dependency.

logion-network/logion-internal#850