### PR TITLE
Enable requester links

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4081,7 +4081,7 @@ dependencies = [
 [[package]]
 name = "logion-shared"
 version = "0.1.1"
-source = "git+https://github.com/logion-network/logion-pallets?branch=feature/requester-links#cd64b3b70ee1b39dcc67f9f8db3abaf137be3adc"
+source = "git+https://github.com/logion-network/logion-pallets?branch=main#646fc5135d4417dbf86bff9d56ee94387509488b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4797,7 +4797,7 @@ dependencies = [
 [[package]]
 name = "pallet-block-reward"
 version = "0.1.0"
-source = "git+https://github.com/logion-network/logion-pallets?branch=feature/requester-links#cd64b3b70ee1b39dcc67f9f8db3abaf137be3adc"
+source = "git+https://github.com/logion-network/logion-pallets?branch=main#646fc5135d4417dbf86bff9d56ee94387509488b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4836,7 +4836,7 @@ dependencies = [
 [[package]]
 name = "pallet-lo-authority-list"
 version = "0.1.1"
-source = "git+https://github.com/logion-network/logion-pallets?branch=feature/requester-links#cd64b3b70ee1b39dcc67f9f8db3abaf137be3adc"
+source = "git+https://github.com/logion-network/logion-pallets?branch=main#646fc5135d4417dbf86bff9d56ee94387509488b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4853,7 +4853,7 @@ dependencies = [
 [[package]]
 name = "pallet-logion-loc"
 version = "0.4.0"
-source = "git+https://github.com/logion-network/logion-pallets?branch=feature/requester-links#cd64b3b70ee1b39dcc67f9f8db3abaf137be3adc"
+source = "git+https://github.com/logion-network/logion-pallets?branch=main#646fc5135d4417dbf86bff9d56ee94387509488b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4871,7 +4871,7 @@ dependencies = [
 [[package]]
 name = "pallet-logion-vault"
 version = "0.1.1"
-source = "git+https://github.com/logion-network/logion-pallets?branch=feature/requester-links#cd64b3b70ee1b39dcc67f9f8db3abaf137be3adc"
+source = "git+https://github.com/logion-network/logion-pallets?branch=main#646fc5135d4417dbf86bff9d56ee94387509488b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4886,7 +4886,7 @@ dependencies = [
 [[package]]
 name = "pallet-logion-vote"
 version = "0.1.0"
-source = "git+https://github.com/logion-network/logion-pallets?branch=feature/requester-links#cd64b3b70ee1b39dcc67f9f8db3abaf137be3adc"
+source = "git+https://github.com/logion-network/logion-pallets?branch=main#646fc5135d4417dbf86bff9d56ee94387509488b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5062,7 +5062,7 @@ dependencies = [
 [[package]]
 name = "pallet-verified-recovery"
 version = "0.1.1"
-source = "git+https://github.com/logion-network/logion-pallets?branch=feature/requester-links#cd64b3b70ee1b39dcc67f9f8db3abaf137be3adc"
+source = "git+https://github.com/logion-network/logion-pallets?branch=main#646fc5135d4417dbf86bff9d56ee94387509488b"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783"
+checksum = "0f2135563fb5c609d2b2b87c1e8ce7bc41b0b45430fa9661f457981503dd5bf0"
 dependencies = [
  "memchr",
 ]
@@ -934,9 +934,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.3"
+version = "4.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84ed82781cea27b43c9b106a979fe450a13a31aab0500595fb3fc06616de08e6"
+checksum = "b1d7b8d5ec32af0fadc644bf1fd509a688c2103b185644bb1e29d164e0703136"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -944,9 +944,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.2"
+version = "4.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb9faaa7c2ef94b2743a21f5a29e6f0010dff4caa69ac8e9d6cf8b6fa74da08"
+checksum = "5179bb514e4d7c2051749d8fcefa2ed6d06a9f4e6d69faf3805f5d80b8cf8d56"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1732,9 +1732,9 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfc4744c1b8f2a09adc0e55242f60b1af195d88596bd8700be74418c056c555"
+checksum = "23d2f3407d9a573d666de4b5bdf10569d73ca9478087346697dcbae6244bfbcd"
 
 [[package]]
 name = "ecdsa"
@@ -4081,7 +4081,7 @@ dependencies = [
 [[package]]
 name = "logion-shared"
 version = "0.1.1"
-source = "git+https://github.com/logion-network/logion-pallets?branch=polkadot-v1.0.0#b09aca282ce1972a6da1dc625bd8b3062556a045"
+source = "git+https://github.com/logion-network/logion-pallets?branch=feature/requester-links#cd64b3b70ee1b39dcc67f9f8db3abaf137be3adc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4239,11 +4239,11 @@ checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "memfd"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc89ccdc6e10d6907450f753537ebc5c5d3460d2e4e62ea74bd571db62c0f9e"
+checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
 dependencies = [
- "rustix 0.37.23",
+ "rustix 0.38.13",
 ]
 
 [[package]]
@@ -4797,7 +4797,7 @@ dependencies = [
 [[package]]
 name = "pallet-block-reward"
 version = "0.1.0"
-source = "git+https://github.com/logion-network/logion-pallets?branch=polkadot-v1.0.0#b09aca282ce1972a6da1dc625bd8b3062556a045"
+source = "git+https://github.com/logion-network/logion-pallets?branch=feature/requester-links#cd64b3b70ee1b39dcc67f9f8db3abaf137be3adc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4836,7 +4836,7 @@ dependencies = [
 [[package]]
 name = "pallet-lo-authority-list"
 version = "0.1.1"
-source = "git+https://github.com/logion-network/logion-pallets?branch=polkadot-v1.0.0#b09aca282ce1972a6da1dc625bd8b3062556a045"
+source = "git+https://github.com/logion-network/logion-pallets?branch=feature/requester-links#cd64b3b70ee1b39dcc67f9f8db3abaf137be3adc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4853,7 +4853,7 @@ dependencies = [
 [[package]]
 name = "pallet-logion-loc"
 version = "0.4.0"
-source = "git+https://github.com/logion-network/logion-pallets?branch=polkadot-v1.0.0#b09aca282ce1972a6da1dc625bd8b3062556a045"
+source = "git+https://github.com/logion-network/logion-pallets?branch=feature/requester-links#cd64b3b70ee1b39dcc67f9f8db3abaf137be3adc"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4871,7 +4871,7 @@ dependencies = [
 [[package]]
 name = "pallet-logion-vault"
 version = "0.1.1"
-source = "git+https://github.com/logion-network/logion-pallets?branch=polkadot-v1.0.0#b09aca282ce1972a6da1dc625bd8b3062556a045"
+source = "git+https://github.com/logion-network/logion-pallets?branch=feature/requester-links#cd64b3b70ee1b39dcc67f9f8db3abaf137be3adc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4886,7 +4886,7 @@ dependencies = [
 [[package]]
 name = "pallet-logion-vote"
 version = "0.1.0"
-source = "git+https://github.com/logion-network/logion-pallets?branch=polkadot-v1.0.0#b09aca282ce1972a6da1dc625bd8b3062556a045"
+source = "git+https://github.com/logion-network/logion-pallets?branch=feature/requester-links#cd64b3b70ee1b39dcc67f9f8db3abaf137be3adc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5062,7 +5062,7 @@ dependencies = [
 [[package]]
 name = "pallet-verified-recovery"
 version = "0.1.1"
-source = "git+https://github.com/logion-network/logion-pallets?branch=polkadot-v1.0.0#b09aca282ce1972a6da1dc625bd8b3062556a045"
+source = "git+https://github.com/logion-network/logion-pallets?branch=feature/requester-links#cd64b3b70ee1b39dcc67f9f8db3abaf137be3adc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8607,9 +8607,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
 dependencies = [
  "winapi-util",
 ]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -45,7 +45,7 @@ sp-timestamp = { version = "4.0.0-dev", git = "https://github.com/paritytech/sub
 sp-inherents = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
 sp-keyring = { version = "24.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
 frame-system = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-pallet-lo-authority-list = { git = "https://github.com/logion-network/logion-pallets", default-features = false,  branch = "feature/requester-links" }
+pallet-lo-authority-list = { git = "https://github.com/logion-network/logion-pallets", default-features = false,  branch = "main" }
 pallet-transaction-payment = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
 
 # These dependencies are used for the node template"s RPCs

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -45,7 +45,7 @@ sp-timestamp = { version = "4.0.0-dev", git = "https://github.com/paritytech/sub
 sp-inherents = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
 sp-keyring = { version = "24.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
 frame-system = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-pallet-lo-authority-list = { git = "https://github.com/logion-network/logion-pallets", default-features = false,  branch = "polkadot-v1.0.0" }
+pallet-lo-authority-list = { git = "https://github.com/logion-network/logion-pallets", default-features = false,  branch = "feature/requester-links" }
 pallet-transaction-payment = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
 
 # These dependencies are used for the node template"s RPCs

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -51,19 +51,19 @@ frame-system-benchmarking = { version = "4.0.0-dev", default-features = false, g
 
 # logion dependencies
 log = { version = "0.4.14", default-features = false }
-logion-shared = { git = "https://github.com/logion-network/logion-pallets", default-features = false,  branch = "feature/requester-links" }
+logion-shared = { git = "https://github.com/logion-network/logion-pallets", default-features = false,  branch = "main" }
 pallet-assets = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-pallet-block-reward = { git = "https://github.com/logion-network/logion-pallets", default-features = false,  branch = "feature/requester-links" }
-pallet-lo-authority-list = { git = "https://github.com/logion-network/logion-pallets", default-features = false,  branch = "feature/requester-links" }
-pallet-logion-loc = { git = "https://github.com/logion-network/logion-pallets", default-features = false,  branch = "feature/requester-links" }
-pallet-logion-vault = { git = "https://github.com/logion-network/logion-pallets", default-features = false,  branch = "feature/requester-links" }
-pallet-logion-vote = { git = "https://github.com/logion-network/logion-pallets", default-features = false,  branch = "feature/requester-links" }
+pallet-block-reward = { git = "https://github.com/logion-network/logion-pallets", default-features = false,  branch = "main" }
+pallet-lo-authority-list = { git = "https://github.com/logion-network/logion-pallets", default-features = false,  branch = "main" }
+pallet-logion-loc = { git = "https://github.com/logion-network/logion-pallets", default-features = false,  branch = "main" }
+pallet-logion-vault = { git = "https://github.com/logion-network/logion-pallets", default-features = false,  branch = "main" }
+pallet-logion-vote = { git = "https://github.com/logion-network/logion-pallets", default-features = false,  branch = "main" }
 pallet-multisig = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v1.0.0" }
 pallet-node-authorization = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v1.0.0" }
 pallet-recovery = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v1.0.0" }
 pallet-session = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
 pallet-validator-set = { default-features = false, git = "https://github.com/logion-network/substrate-validator-set.git", package = "substrate-validator-set", branch = "polkadot-v1.0.0" }
-pallet-verified-recovery = { git = "https://github.com/logion-network/logion-pallets", default-features = false,  branch = "feature/requester-links" }
+pallet-verified-recovery = { git = "https://github.com/logion-network/logion-pallets", default-features = false,  branch = "main" }
 pallet-treasury = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v1.0.0" }
 
 [build-dependencies]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -51,19 +51,19 @@ frame-system-benchmarking = { version = "4.0.0-dev", default-features = false, g
 
 # logion dependencies
 log = { version = "0.4.14", default-features = false }
-logion-shared = { git = "https://github.com/logion-network/logion-pallets", default-features = false,  branch = "polkadot-v1.0.0" }
+logion-shared = { git = "https://github.com/logion-network/logion-pallets", default-features = false,  branch = "feature/requester-links" }
 pallet-assets = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-pallet-block-reward = { git = "https://github.com/logion-network/logion-pallets", default-features = false,  branch = "polkadot-v1.0.0" }
-pallet-lo-authority-list = { git = "https://github.com/logion-network/logion-pallets", default-features = false,  branch = "polkadot-v1.0.0" }
-pallet-logion-loc = { git = "https://github.com/logion-network/logion-pallets", default-features = false,  branch = "polkadot-v1.0.0" }
-pallet-logion-vault = { git = "https://github.com/logion-network/logion-pallets", default-features = false,  branch = "polkadot-v1.0.0" }
-pallet-logion-vote = { git = "https://github.com/logion-network/logion-pallets", default-features = false,  branch = "polkadot-v1.0.0" }
+pallet-block-reward = { git = "https://github.com/logion-network/logion-pallets", default-features = false,  branch = "feature/requester-links" }
+pallet-lo-authority-list = { git = "https://github.com/logion-network/logion-pallets", default-features = false,  branch = "feature/requester-links" }
+pallet-logion-loc = { git = "https://github.com/logion-network/logion-pallets", default-features = false,  branch = "feature/requester-links" }
+pallet-logion-vault = { git = "https://github.com/logion-network/logion-pallets", default-features = false,  branch = "feature/requester-links" }
+pallet-logion-vote = { git = "https://github.com/logion-network/logion-pallets", default-features = false,  branch = "feature/requester-links" }
 pallet-multisig = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v1.0.0" }
 pallet-node-authorization = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v1.0.0" }
 pallet-recovery = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v1.0.0" }
 pallet-session = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
 pallet-validator-set = { default-features = false, git = "https://github.com/logion-network/substrate-validator-set.git", package = "substrate-validator-set", branch = "polkadot-v1.0.0" }
-pallet-verified-recovery = { git = "https://github.com/logion-network/logion-pallets", default-features = false,  branch = "polkadot-v1.0.0" }
+pallet-verified-recovery = { git = "https://github.com/logion-network/logion-pallets", default-features = false,  branch = "feature/requester-links" }
 pallet-treasury = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v1.0.0" }
 
 [build-dependencies]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -53,7 +53,7 @@ pub use sp_runtime::{Perbill, Permill};
 use frame_support::codec::{Decode, Encode};
 use frame_system::EnsureRoot;
 use logion_shared::{Beneficiary, CreateRecoveryCallFactory, MultisigApproveAsMultiCallFactory, MultisigAsMultiCallFactory, DistributionKey, LegalFee, EuroCent};
-use pallet_logion_loc::{LocType, Hasher, migrations::v20::AddCustomLegalFee};
+use pallet_logion_loc::{LocType, Hasher, migrations::v21::EnableRequesterLinks};
 use pallet_multisig::Timepoint;
 use scale_info::TypeInfo;
 
@@ -757,7 +757,7 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
-	AddCustomLegalFee<Runtime>,
+	EnableRequesterLinks<Runtime>,
 >;
 
 #[cfg(feature = "runtime-benchmarks")]


### PR DESCRIPTION
* Companion of https://github.com/logion-network/logion-pallets/pull/37
* `logion-pallets` branch will be updated after above PR is merged into polkadot-v1.0.0.
* Runtime spec version has already been incremented with the upgrade to polkadot-v1.0.0.

logion-network/logion-internal#995